### PR TITLE
Support apple M series monitoring

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,11 +8,11 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 MLDataDevices = "7e8f7934-dd98-4c1a-8fe8-92b47a384d40"
 Term = "22787eb5-b846-44ae-b979-8e399b8463ab"
 UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
-MacOSIOReport = "27799fc1-e272-4181-9793-a9e1fcba685b"
 
 [weakdeps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
+MacOSIOReport = "27799fc1-e272-4181-9793-a9e1fcba685b"
 
 [extensions]
 TerminalSystemMonitorCUDAExt = "CUDA"

--- a/Project.toml
+++ b/Project.toml
@@ -8,12 +8,18 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 MLDataDevices = "7e8f7934-dd98-4c1a-8fe8-92b47a384d40"
 Term = "22787eb5-b846-44ae-b979-8e399b8463ab"
 UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
-
-[extensions]
-TerminalSystemMonitorCUDAExt = "CUDA"
+MacOSIOReport = "27799fc1-e272-4181-9793-a9e1fcba685b"
 
 [weakdeps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
+
+[extensions]
+TerminalSystemMonitorCUDAExt = "CUDA"
+TerminalSystemMonitorMetalExt = ["Metal"]
+
+[sources]
+MacOSIOReport = {url = "https://github.com/AtelierArith/MacOSIOReport.jl", rev="main"}
 
 [compat]
 Aqua = "0.8.9"
@@ -21,6 +27,8 @@ CUDA = "5.5.2"
 Dates = "1"
 JET = "0.9.12"
 MLDataDevices = "1.5.3"
+MacOSIOReport = "0.1.0"
+Metal = "1.5.1"
 ReTestItems = "1.29.0"
 Term = "2.0.6"
 Test = "1"
@@ -28,11 +36,11 @@ UnicodePlots = "3.7.0"
 julia = "1.10"
 
 [extras]
+MacOSIOReport = "27799fc1-e272-4181-9793-a9e1fcba685b"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 ReTestItems = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "JET", "ReTestItems", "Test", "CUDA"]
+test = ["Aqua", "JET", "ReTestItems", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -11,15 +11,11 @@ UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [weakdeps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
-Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
 MacOSIOReport = "27799fc1-e272-4181-9793-a9e1fcba685b"
 
 [extensions]
 TerminalSystemMonitorCUDAExt = "CUDA"
-TerminalSystemMonitorMetalExt = ["Metal"]
-
-[sources]
-MacOSIOReport = {url = "https://github.com/AtelierArith/MacOSIOReport.jl", rev="main"}
+TerminalSystemMonitorMacOSIOReportExt = "MacOSIOReport"
 
 [compat]
 Aqua = "0.8.9"
@@ -28,7 +24,6 @@ Dates = "1"
 JET = "0.9.12"
 MLDataDevices = "1.5.3"
 MacOSIOReport = "0.1.0"
-Metal = "1.5.1"
 ReTestItems = "1.29.0"
 Term = "2.0.6"
 Test = "1"
@@ -36,7 +31,6 @@ UnicodePlots = "3.7.0"
 julia = "1.10"
 
 [extras]
-MacOSIOReport = "27799fc1-e272-4181-9793-a9e1fcba685b"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 ReTestItems = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"

--- a/ext/TerminalSystemMonitorCUDAExt/TerminalSystemMonitorCUDAExt.jl
+++ b/ext/TerminalSystemMonitorCUDAExt/TerminalSystemMonitorCUDAExt.jl
@@ -11,7 +11,7 @@ function _plot_gpu_utilization_rates(gpu_id, dev::CUDA.CuDevice)
     nvml_dev = CUDA.NVML.Device(uuid(dev); mig)
     x = string(gpu_id)
     y = 100 * CUDA.NVML.utilization_rates(nvml_dev).compute
-    return barplot([x], [y], maximum = 100, width = max(5, 15))
+    return barplot([x], [y], maximum = 100, width = 15)
 end
 
 function TerminalSystemMonitor.plot_gpu_utilization_rates(::Type{CUDADevice})
@@ -56,7 +56,7 @@ function _plot_gpu_memory_utilization(dev::CUDA.CuDevice)
         # Adds a space for better styling
         name = " $(memorytotal) $(memorytotal_unit)",
         maximum = memorytotal,
-        width = max(5, 15),
+        width = 15,
     )
 end
 

--- a/ext/TerminalSystemMonitorMacOSIOReportExt/TerminalSystemMonitorMacOSIOReportExt.jl
+++ b/ext/TerminalSystemMonitorMacOSIOReportExt/TerminalSystemMonitorMacOSIOReportExt.jl
@@ -1,10 +1,9 @@
-module TerminalSystemMonitorMetalExt
+module TerminalSystemMonitorMacOSIOReportExt
 
 using MLDataDevices: MetalDevice
 using UnicodePlots: barplot
 import TerminalSystemMonitor
-using Metal: MTLDevice
-using MacOSIOReport: Sampler, get_metrics
+using MacOSIOReport: Sampler, get_metrics, MTLDevice
 using TerminalSystemMonitor: extract_number_and_unit
 
 function _plot_cpu_utilization_rates(id, usage)
@@ -40,4 +39,4 @@ function TerminalSystemMonitor.plot_gpu_utilization_rates(::Type{MetalDevice})
     return plts
 end
 
-end # module TerminalSystemMonitorCUDAExt
+end # module TerminalSystemMonitorMacOSIOReportExt

--- a/ext/TerminalSystemMonitorMetalExt/TerminalSystemMonitorMetalExt.jl
+++ b/ext/TerminalSystemMonitorMetalExt/TerminalSystemMonitorMetalExt.jl
@@ -1,0 +1,42 @@
+module TerminalSystemMonitorMetalExt
+
+using Metal
+using MLDataDevices: MetalDevice
+using UnicodePlots: barplot
+import TerminalSystemMonitor
+using MacOSIOReport: Sampler, get_metrics
+using TerminalSystemMonitor: extract_number_and_unit
+
+function _plot_cpu_utilization_rates(id, usage)
+    x = string(id)
+    y = usage
+    return barplot([x], [y], maximum = 100, width = 15)
+end
+
+function TerminalSystemMonitor.plot_cpu_utilization_rates(::Type{MetalDevice})
+    sampler = Sampler()
+    msec = UInt(1000)
+    m = get_metrics(sampler, msec)
+    cpu_ids = ["E-CPU: ", "P-CPU: "]
+    usages = [
+        round(100 * m.ecpu_usage[2], digits = 1),
+        round(100 * m.pcpu_usage[2], digits = 1),
+    ]
+    return Any[barplot(cpu_ids, usages, maximum = 100, width = 15)]
+end
+
+function TerminalSystemMonitor.plot_gpu_utilization_rates(::Type{MetalDevice})
+    sampler = Sampler()
+    msec = UInt(1000)
+    m = get_metrics(sampler, msec)
+    gpu_usages = [
+        ("GPU: ", round(100 * m.gpu_usage[2], digits = 1)),
+    ]
+    plts = []
+    for (id, usage) in gpu_usages
+        push!(plts, _plot_cpu_utilization_rates(id, usage))
+    end
+    return plts
+end
+
+end # module TerminalSystemMonitorCUDAExt

--- a/ext/TerminalSystemMonitorMetalExt/TerminalSystemMonitorMetalExt.jl
+++ b/ext/TerminalSystemMonitorMetalExt/TerminalSystemMonitorMetalExt.jl
@@ -1,9 +1,9 @@
 module TerminalSystemMonitorMetalExt
 
-using Metal
 using MLDataDevices: MetalDevice
 using UnicodePlots: barplot
 import TerminalSystemMonitor
+using Metal: MTLDevice
 using MacOSIOReport: Sampler, get_metrics
 using TerminalSystemMonitor: extract_number_and_unit
 
@@ -15,7 +15,7 @@ end
 
 function TerminalSystemMonitor.plot_cpu_utilization_rates(::Type{MetalDevice})
     sampler = Sampler()
-    msec = UInt(1000)
+    msec = UInt(500)
     m = get_metrics(sampler, msec)
     cpu_ids = ["E-CPU: ", "P-CPU: "]
     usages = [
@@ -27,15 +27,16 @@ end
 
 function TerminalSystemMonitor.plot_gpu_utilization_rates(::Type{MetalDevice})
     sampler = Sampler()
-    msec = UInt(1000)
+    msec = UInt(500)
     m = get_metrics(sampler, msec)
     gpu_usages = [
         ("GPU: ", round(100 * m.gpu_usage[2], digits = 1)),
     ]
     plts = []
-    for (id, usage) in gpu_usages
-        push!(plts, _plot_cpu_utilization_rates(id, usage))
-    end
+    chip_name = String(MTLDevice(1).name)
+    push!(
+        plts, barplot(["GPU: "], [round(100 * m.gpu_usage[2], digits = 1)], xlabel=chip_name, maximum=100, width=15)
+    )
     return plts
 end
 

--- a/src/TerminalSystemMonitor.jl
+++ b/src/TerminalSystemMonitor.jl
@@ -165,6 +165,9 @@ function main(dummyargs...)
                getproperty(getproperty(Main, :CUDA), :functional)()
                 wait(t1)
                 f = fetch(t1)
+                if isnothing(f)
+                    break
+                end
                 cudaplts = []
                 n = max(1, cols ÷ 50)
                 plts1 = plot_gpu_utilization_rates(CUDADevice)::Vector{Any}

--- a/src/TerminalSystemMonitor.jl
+++ b/src/TerminalSystemMonitor.jl
@@ -164,7 +164,7 @@ function main(dummyargs...)
                 f /= foldl(/, map(c -> prod(UnicodePlots.panel.(c)), gpuchunks))
             end
 
-            if isdefined(Main, :Metal)
+            if isdefined(Main, :Metal) && Sys.ARCH == :aarch64
                 metalplts = []
                 n = max(1, cols ÷ 50)
                 plts1 = plot_cpu_utilization_rates(MetalDevice)::Vector{Any}


### PR DESCRIPTION
This PR supports visualizing GPU usage on an M-series macOS device.

```julia
julia> using MacOSIOReport; using TerminalSystemMonitor; monitor()
```

<img width="847" alt="image" src="https://github.com/user-attachments/assets/e209e285-c54a-4125-b2dc-3b845d85b349" />
